### PR TITLE
Fix causal forest documentation errors

### DIFF
--- a/R/causal_forest.R
+++ b/R/causal_forest.R
@@ -7,6 +7,7 @@
 #' @importFrom rlang enquo
 #' @importFrom rlang expr
 #' @importFrom rlang abort
+NULL
 
 # Register model and engine ----------------------------------------------------
 
@@ -58,7 +59,7 @@ causal_forest <- function(mode = "regression",subclasses = NULL, num.trees = NUL
 #' @return A fitted `grf` causal forest object.
 #'
 #' @keywords internal
-#' @noRd
+#' @export
 fit_causal_forest <- function(formula, data, treatment = "W", ...) {
   # Capture additional args
   dots <- list(...)
@@ -91,7 +92,7 @@ fit_causal_forest <- function(formula, data, treatment = "W", ...) {
 #' @return Predictions as a list object from `grf::predict`.
 #'
 #' @keywords internal
-#' @noRd
+#' @export
 predict_causal_forest <- function(object, new_data, ...) {
   fit_obj <- if (!is.null(object$fit)) object$fit else object
   terms <- fit_obj$terms

--- a/R/causal_forest.R
+++ b/R/causal_forest.R
@@ -4,13 +4,16 @@
 #' @import parsnip
 #' @importFrom hardhat extract_parameter_set_dials
 #' @importFrom dials finalize
-#' @importFrom rlang enquo expr abort
+#' @importFrom rlang enquo
+#' @importFrom rlang expr
+#' @importFrom rlang abort
 
 # Register model and engine ----------------------------------------------------
 
 #' Causal Forest Model Specification
 #'
-#' A parsnip model specification for causal forests using the `grf` package.
+#' @title Causal Forest Model Specification
+#' @description A parsnip model specification for causal forests using the `grf` package.
 #' This model estimates heterogeneous treatment effects with a causal forest.
 #'
 #' @param mode A character string specifying the model mode. Only `"regression"` is supported.


### PR DESCRIPTION
Fixes Roxygen2 documentation errors and exports internal `parsnip` helper functions.

The original `devtools::document()` errors stemmed from Roxygen2 misinterpreting the function description as part of an `@importFrom` directive and the absence of `@title` tags. Additionally, `parsnip` tests failed because `fit_causal_forest` and `predict_causal_forest` were marked `@noRd` (internal) but needed to be exported for `parsnip` to use them. This PR addresses these by reformatting Roxygen2 tags and explicitly exporting the necessary functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-a92b1296-8636-4a56-af70-c1715f54dc7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a92b1296-8636-4a56-af70-c1715f54dc7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

